### PR TITLE
Adding support for new "taxonkit lca" command

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -12,7 +12,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: [3.6, 3.7, 3.8]
     steps:
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Pursuant to #3, this branch adds support for the new `taxonkit lca` command. Input to the command can be a list of taxids (ints or strings), or to support multiple queries at once, a list of taxid lists (with `multi=True`). The `-s` and `-i` flags aren't supported since they are less relevant in a Python API.