### PR TITLE
Updated routine tests that failed for May 2023

### DIFF
--- a/pytaxonkit.py
+++ b/pytaxonkit.py
@@ -528,7 +528,7 @@ def test_lineage_single_taxid():
 def test_lineage_threads():
     result = lineage(["200643"], threads=1)
     assert result.FullLineageRanks.iloc[0] == "no rank;superkingdom;clade;clade;phylum;class"
-    expected = "cellular organisms;Bacteria;FCB group;Bacteroidetes/Chlorobi group;Bacteroidota;Bacteroidia"
+    expected = "cellular organisms;Bacteria;FCB group;Bacteroidota/Chlorobiota group;Bacteroidota;Bacteroidia"
     assert result.FullLineage.iloc[0] == expected
 
 


### PR DESCRIPTION
Updated `test_lineage_threads()` expected clade output with the new updates made to the taxonomic database.