### PR TITLE
Routine minor fix to accommodate taxonomy update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Routine updates to accommodate changes to NCBI taxonomy (#51, #54)
+
+
 ## [0.10.1] 2026-01-14
 
 ### Fixed

--- a/sweetleaf.json
+++ b/sweetleaf.json
@@ -240,7 +240,8 @@
             "2945531 [species] Symplocos peruviana": {},
             "2945532 [species] Symplocos saxatilis": {},
             "2945533 [species] Symplocos sulcata": {},
-            "2945534 [species] Symplocos theifolia": {}
+            "2945534 [species] Symplocos theifolia": {},
+            "3695220 [species] Symplocos hainanensis": {}
         },
         "2601367 [no rank] environmental samples": {
             "2601368 [species] Symplocos environmental sample": {}


### PR DESCRIPTION
Yesterday's monthly scheduled CI build failed due to an update to the NCBI taxonomy database. This PR makes a minor change to the test suite to accommodate this update.