### PR TITLE
Troubleshoot CI

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -37,7 +37,6 @@ jobs:
           popd
       - name: Install
         run: |
-          python -m pip install --upgrade pip
           pip install .
       - name: Style check
         run: |

--- a/pytaxonkit.py
+++ b/pytaxonkit.py
@@ -206,7 +206,7 @@ def list(ids, raw=False, threads=None, data_dir=None, debug=False):
     ...     print(f'Top level result: {taxon.name} ({taxon.taxid}); {len(subtaxa)} related taxa')
     ...
     Top level result: Polistes comanchus (268197); 2 related taxa
-    Top level result: Bos (9903); 33 related taxa
+    Top level result: Bos (9903); 34 related taxa
     >>> subtaxa[0]
     BasicTaxon(taxid=9904, rank='species', name='Bos gaurus')
     >>> pytaxonkit.list([9605], raw=True)
@@ -1222,10 +1222,10 @@ def test_lca_keep_invalid_multi():
 
 
 @pytest.mark.parametrize(
-    "domulti, ids,result",
+    "domulti, ids, result",
     [
-        (False, [775536, 2238728, 1121123211234321], None),
-        (True, [[1766280, 406491, 2568889], [11111111111, 20487, 760325]], [None, None]),
+        (False, [775536, 2238728, 3602992145], None),
+        (True, [[3198828, 406491, 2222222222], [1111111111, 20487, 3674241]], [None, None]),
     ],
 )
 def test_lca_all_missing(ids, domulti, result):

--- a/sweetleaf.json
+++ b/sweetleaf.json
@@ -183,6 +183,7 @@
             "1340892 [species] Symplocos xylopyrena": {},
             "1382184 [species] Symplocos ampulliformis": {},
             "1489813 [species] Symplocos acuminata": {},
+            "1538024 [species] Symplocos munda": {},
             "1603839 [species] Symplocos crassifolia": {},
             "1603840 [species] Symplocos urceolaris": {},
             "1609893 [species] Symplocos adinandrifolia": {
@@ -194,6 +195,7 @@
             "1619550 [species] Symplocos harroldii": {},
             "1619551 [species] Symplocos stawellii": {},
             "1679332 [species] Symplocos yunnanensis": {},
+            "1789566 [species] Symplocos obtusa": {},
             "1827319 [species] Symplocos crassipes": {},
             "1842783 [species] Symplocos thwaitesii": {},
             "2072302 [species] Symplocos estrellensis": {},


### PR DESCRIPTION
Build failed initially due to a pip thing, but changes to accommodate recent NCBI Taxonomy Database updates were also required.